### PR TITLE
feat: hide Create Claimable Balance transactions

### DIFF
--- a/src/Account/components/AccountTransactions.tsx
+++ b/src/Account/components/AccountTransactions.tsx
@@ -110,20 +110,7 @@ function AccountTransactions(props: { account: Account }) {
     [recentTxs.transactions]
   )
 
-  // TODO: make this array modifyable via UI (some kind of filtering functionality)
-  const activeFilters = [excludeClaimableFilter]
-
-  const filteredTxs = React.useMemo(
-    () =>
-      // combine all the filers with logical AND
-      txs.filter(tx =>
-        activeFilters.reduce((res, filter) => {
-          res = res && filter(tx)
-          return res
-        }, true)
-      ),
-    [txs]
-  )
+  const filteredTxs = React.useMemo(() => txs.filter(excludeClaimableFilter), [txs])
 
   return (
     <>

--- a/src/Account/components/TransactionList.tsx
+++ b/src/Account/components/TransactionList.tsx
@@ -571,7 +571,7 @@ function TransactionList(props: TransactionListProps) {
     [props.transactions, props.account.publicKey, props.account.testnet, classes.listItem, openTransaction]
   )
 
-  if (props.transactions.length === 0) {
+  if (props.transactions.length === 0 && !props.olderTransactionsAvailable) {
     return null
   }
 

--- a/src/Account/components/TransactionList.tsx
+++ b/src/Account/components/TransactionList.tsx
@@ -409,6 +409,7 @@ export const TransactionListItem = React.memo(function TransactionListItem(props
   const isSmallScreen = useIsMobile()
 
   const { onOpenTransaction } = props
+  // TODO: take decoded tx from props
   const restoredTransaction = React.useMemo(
     () => TransactionBuilder.fromXDR(props.transactionEnvelopeXdr, props.testnet ? Networks.TESTNET : Networks.PUBLIC),
     [props.testnet, props.transactionEnvelopeXdr]
@@ -514,6 +515,7 @@ function TransactionList(props: TransactionListProps) {
     const network = props.account.testnet ? Networks.TESTNET : Networks.PUBLIC
     const txResponse = props.transactions.find(recentTx => recentTx.hash === openedTxHash)
 
+    // TODO: use decoded transaction from cache once we have it
     let tx = txResponse ? TransactionBuilder.fromXDR(txResponse.envelope_xdr, network) : null
 
     if (tx instanceof FeeBumpTransaction) {

--- a/src/Generic/hooks/_caches.ts
+++ b/src/Generic/hooks/_caches.ts
@@ -1,6 +1,6 @@
 import { TransferServerInfo } from "@satoshipay/stellar-transfer"
 import { multicast, Observable, ObservableLike } from "observable-fns"
-import { Asset, Horizon, ServerApi } from "stellar-sdk"
+import { Asset, Horizon, ServerApi, Transaction } from "stellar-sdk"
 import { trackError } from "~App/contexts/notifications"
 import { AccountData } from "../lib/account"
 import { FixedOrderbookRecord } from "../lib/orderbook"
@@ -98,9 +98,13 @@ function createAssetPairCacheKey([horizonURLs, selling, buying]: readonly [strin
   return `${horizonURLs.map(url => `${url}:`)}${stringifyAsset(selling)}:${stringifyAsset(buying)}`
 }
 
+export interface DecodedTransactionResponse extends Horizon.TransactionResponse {
+  decodedTx: Transaction
+}
+
 export interface TransactionHistory {
   olderTransactionsAvailable: boolean
-  transactions: Horizon.TransactionResponse[]
+  transactions: DecodedTransactionResponse[]
 }
 
 export interface OfferHistory {

--- a/src/Generic/hooks/useFilteredTransactions.ts
+++ b/src/Generic/hooks/useFilteredTransactions.ts
@@ -1,0 +1,39 @@
+import React from "react"
+import { DecodedTransactionResponse } from "./_caches"
+import { useLiveRecentTransactions, useOlderTransactions } from "./stellar-subscriptions"
+
+function useFilteredTransactions(
+  accountId: string,
+  testnet: boolean,
+  filter: (txs: DecodedTransactionResponse[]) => DecodedTransactionResponse[]
+) {
+  const [refetchKey, setRefetchKey] = React.useState<number>(Date.now())
+  const limit = 15
+  const { transactions, olderTransactionsAvailable } = useLiveRecentTransactions(accountId, testnet, refetchKey)
+  const fetchMore = useOlderTransactions(accountId, testnet)
+  const txs = React.useMemo(() => filter(transactions), [transactions])
+
+  const fetchMoreTransactions = async (count: number = 0): Promise<void> => {
+    if (count >= limit) {
+      setRefetchKey(Date.now())
+      return
+    }
+    const unfiltered = await fetchMore()
+    const moreTxs = filter(unfiltered)
+    return fetchMoreTransactions(count + moreTxs.length)
+  }
+
+  React.useEffect(() => {
+    if (txs.length < limit) {
+      fetchMoreTransactions(txs.length)
+    }
+  }, [txs])
+
+  return {
+    olderTransactionsAvailable,
+    transactions: txs,
+    fetchMoreTransactions
+  }
+}
+
+export default useFilteredTransactions

--- a/src/Workers/net-worker/stellar-network.ts
+++ b/src/Workers/net-worker/stellar-network.ts
@@ -746,6 +746,7 @@ export async function fetchLatestAccountEffect(horizonURL: string, accountID: st
 
 export interface FetchTransactionsOptions extends PaginationOptions {
   emptyOn404?: boolean
+  emptyOn410?: boolean
 }
 
 export async function fetchAccountTransactions(
@@ -766,7 +767,7 @@ export async function fetchAccountTransactions(
   )
   const response = await fetchQueue.add(() => fetch(String(url)), { priority: 1 })
 
-  if (response.status === 404 && options.emptyOn404) {
+  if ((response.status === 404 && options.emptyOn404) || (response.status === 410 && options.emptyOn410)) {
     return {
       _links: {
         next: { href: String(url) },


### PR DESCRIPTION
Changes here:
- ~decoding tx envelopes in AccountTransactions component. This should be cached (task for later)~ Done on the stellar-network level now and caching decoded txs (see below)
- create `excludeClaimableFilter`: use decoded envelope to check tx operations if all of them are of `createClaimableBalance` type
- created useFilteredTransactions hook, accepting a filter function. For now it is just hardcoded `excludeClaimableFilter`, the plan is to make a UI for this filter later so it could be switched on/off plus adding other filters. TODO: followup with corresponding UI change
- now decoding transaction XDR right away when fetching from horizon and adding to the cache with decoded tx already. So the cache contains transactions decoded (in `decodedTx` attribute). You can take advantage of that in other places and stop decoding XDR in-place (I will do this in a separate PR to keep this one cleaner). TODO: follow up with a separate PR to stop decoding XDR in UI components
- `fetchMoreTransactions` of `useFilteredTransactions` does not just return the next batch of transactions now like it was before (as implemented in `useOlderTransactions`), but instead checks if the number of fetched transactions filtered with a given filter is at least 15 (limit for the batch). If less, it calls itself one more time and continues to do so until the total number of freshly fetched filtered transactions is at least 15 or no more transactions to fetch. **This allows to overcome the problem when there are a lot of "create claimable balance" transactions and simple click on "Load more" returns very little or even nothing.**