### PR TITLE
feat: filter dust txs

### DIFF
--- a/src/Account/components/AccountTransactions.tsx
+++ b/src/Account/components/AccountTransactions.tsx
@@ -19,9 +19,13 @@ import FriendbotButton from "./FriendbotButton"
 import OfferList from "./OfferList"
 import { InteractiveSignatureRequestList } from "./SignatureRequestList"
 import TransactionList from "./TransactionList"
+import { isDustTransaction } from "~Generic/lib/transaction"
 
 const excludeClaimableFilter = (tx: DecodedTransactionResponse) =>
   !tx.decodedTx.operations.every(o => o.type === "createClaimableBalance")
+
+const excludeDustFilter = (account: Account, tx: DecodedTransactionResponse) =>
+  !isDustTransaction(tx.decodedTx, account)
 
 function PendingMultisigTransactions(props: { account: Account }) {
   const { pendingSignatureRequests } = React.useContext(SignatureDelegationContext)
@@ -75,7 +79,8 @@ function AccountTransactions(props: { account: Account }) {
   const [moreTxsLoadingState, handleMoreTxsFetch] = useLoadingState()
 
   const txsFilter = React.useCallback(
-    (txs: DecodedTransactionResponse[]) => txs.filter(excludeClaimableFilter), // TODO: make it switchable via UI (next task)
+    (txs: DecodedTransactionResponse[]) =>
+      txs.filter(tx => excludeClaimableFilter(tx) && excludeDustFilter(account, tx)), // TODO: make it switchable via UI (next task)
     []
   )
 

--- a/src/Generic/lib/paymentSummary.ts
+++ b/src/Generic/lib/paymentSummary.ts
@@ -44,7 +44,7 @@ export function getPaymentSummary(accountPublicKey: string, transaction: Transac
       balanceChanges.push({
         asset,
         balanceChange,
-        publicKeys: remotePublicKey ? [remotePublicKey] : []
+        publicKeys: remotePublicKey ? [remotePublicKey] : [] // TODO: this doesn't work okay for incloming multisig txs?
       })
     }
   }


### PR DESCRIPTION
What's done here:
Incoming XLM txs of amount less then 0.001 XLM are considered dust and are hidden from the transaction list (see screenshots below)

Special case: keep showing dust tx if it is coming from our own account (see screenshot below)

Closes #19

Before: 
<img width="421" alt="image" src="https://github.com/Montelibero/mtl_solar/assets/163447/0a018f32-c13f-413a-b70b-107136a6c937">

After:
<img width="419" alt="image" src="https://github.com/Montelibero/mtl_solar/assets/163447/0523dda8-06ff-4e02-b130-fd56622dd80a">
