### PR TITLE
feat: add options to toggle Dust and Claimable Balance filters

### DIFF
--- a/i18n/locales/en/app-settings.json
+++ b/i18n/locales/en/app-settings.json
@@ -60,6 +60,24 @@
         "primary": "Manage Trusted Services",
         "secondary": "Remove Trusted Services"
       }
+    },
+    "dust": {
+      "text": {
+        "primary": "Show dust transactions",
+        "secondary": {
+          "hidden": "Transactions smaller than 0.001 XLM are hidden in transaction list",
+          "shown": "Transactions smaller than 0.001 XLM are shown in transaction list"
+        }
+      }
+    },
+    "create-claimable-balance": {
+      "text": {
+        "primary": "Show Create Claimable Balance transactions",
+        "secondary": {
+          "hidden": "Create Claimable Balance transactions are hidden in transaction list",
+          "shown": "Create Claimable Balance transactions are shown in transaction list"
+        }
+      }
     }
   },
   "trusted-services": {

--- a/i18n/locales/es/app-settings.json
+++ b/i18n/locales/es/app-settings.json
@@ -60,6 +60,24 @@
         "primary": "Administrar Trusted Services",
         "secondary": "Remover Trusted Services"
       }
+    },
+    "dust": {
+      "text": {
+        "primary": "Mostrar transacciones de polvo",
+        "secondary": {
+          "hidden": "Las transacciones inferiores a 0,001 XLM no se muestran en la vista de transacciones",
+          "shows": "Las transacciones inferiores a 0,001 XLM se muestran en la vista de transacciones"
+        }
+      }
+    },
+    "create-claimable-balance": {
+      "text": {
+        "primary": "Mostrar transacciones de Crear Saldo Reclamable",
+        "secondary": {
+          "hidden": "Las transacciones de Crear Saldo Reclamable no se muestran en la vista de transacciones",
+          "shown": "Las transacciones de Crear Saldo Reclamable se muestran en la vista de transacciones"
+        }
+      }
     }
   },
   "trusted-services": {

--- a/i18n/locales/it/app-settings.json
+++ b/i18n/locales/it/app-settings.json
@@ -60,6 +60,24 @@
         "primary": "Gestisci servizi attendibili",
         "secondary": "Rimuovi servizi attendibili"
       }
+    },
+    "dust": {
+      "text": {
+        "primary": "Mostra transazioni di polvere",
+        "secondary": {
+          "hidden": "Le transazioni inferiori a 0,001 XLM sono nascoste nella vista delle transazioni",
+          "shown": "Le transazioni inferiori a 0,001 XLM vengono visualizzate nella vista delle transazioni"
+        }
+      }
+    },
+    "create-claimable-balance": {
+      "text": {
+        "primary": "Mostra le transazioni Creare Saldo Reclamabile",
+        "secondary": {
+          "hidden": "Le transazioni Crea Saldo Reclamabile sono nascoste nella vista delle transazioni",
+          "shown": "Le transazioni Crea Saldo Reclamabile sono visualizzate nella vista transazioni"
+        }
+      }
     }
   },
   "trusted-services": {

--- a/i18n/locales/ru/app-settings.json
+++ b/i18n/locales/ru/app-settings.json
@@ -60,6 +60,24 @@
         "primary": "Управление доверенными сервисами",
         "secondary": "Удаление доверенных сервисов"
       }
+    },
+    "dust": {
+      "text": {
+        "primary": "Показывать пыль",
+        "secondary": {
+          "hidden": "Транзакции меньше, чем 0.001 XLM, скрыты в списке транзакций",
+          "shown": "Транзакции меньше, чем 0.001 XLM, видны в списке транзакций"
+        }
+      }
+    },
+    "create-claimable-balance": {
+      "text": {
+        "primary": "Показывать траназакции Create Claimable Balance",
+        "secondary": {
+          "hidden": "Транзакции Create Claimable Balance скрыты в списке транзакций",
+          "shown": "Транзакции Create Claimable Balance видны в списке транзакций"
+        }
+      }
     }
   },
   "trusted-services": {

--- a/shared/types/platform.d.ts
+++ b/shared/types/platform.d.ts
@@ -11,6 +11,8 @@ declare namespace Platform {
     multisignature: boolean
     testnet: boolean
     trustedServices: TrustedService[]
+    showDust: boolean
+    showClaimableBalanceTxs: boolean
   }
 }
 

--- a/src/Account/components/AccountTransactions.tsx
+++ b/src/Account/components/AccountTransactions.tsx
@@ -72,6 +72,7 @@ function PendingMultisigTransactions(props: { account: Account }) {
 
 function AccountTransactions(props: { account: Account }) {
   const { account } = props
+  const { showDust, showClaimableBalanceTxs } = React.useContext(SettingsContext)
   const { t } = useTranslation()
   const accountData = useLiveAccountData(account.accountID, account.testnet)
   const horizonURLs = useHorizonURLs(account.testnet)
@@ -80,7 +81,9 @@ function AccountTransactions(props: { account: Account }) {
 
   const txsFilter = React.useCallback(
     (txs: DecodedTransactionResponse[]) =>
-      txs.filter(tx => excludeClaimableFilter(tx) && excludeDustFilter(account, tx)), // TODO: make it switchable via UI (next task)
+      txs.filter(tx => {
+        return (showClaimableBalanceTxs || excludeClaimableFilter(tx)) && (showDust || excludeDustFilter(account, tx))
+      }),
     []
   )
 

--- a/src/App/contexts/settings.tsx
+++ b/src/App/contexts/settings.tsx
@@ -30,10 +30,14 @@ interface ContextType {
   setLanguage: (language: string | undefined) => void
   setSetting: (key: keyof Platform.SettingsData, value: any) => void
   showTestnet: boolean
+  showDust: boolean
+  showClaimableBalanceTxs: boolean
   toggleBiometricLock: () => void
   toggleMultiSignature: () => void
   toggleTestnet: () => void
   toggleHideMemos: () => void
+  toggleShowDust: () => void
+  toggleShowClaimableBalanceTxs: () => void
   trustedServices: TrustedService[]
   updateAvailable: boolean
 }
@@ -49,6 +53,8 @@ const initialSettings: SettingsState = {
   initialized: false,
   multisignature: false,
   testnet: false,
+  showDust: false,
+  showClaimableBalanceTxs: false,
   trustedServices: []
 }
 
@@ -70,11 +76,15 @@ const SettingsContext = React.createContext<ContextType>({
   multiSignatureCoordinator,
   setLanguage: () => undefined,
   setSetting: () => undefined,
+  showDust: false,
+  showClaimableBalanceTxs: false,
   showTestnet: initialSettings.testnet,
   toggleBiometricLock: () => undefined,
   toggleMultiSignature: () => undefined,
   toggleTestnet: () => undefined,
   toggleHideMemos: () => undefined,
+  toggleShowDust: () => undefined,
+  toggleShowClaimableBalanceTxs: () => undefined,
   trustedServices: initialSettings.trustedServices,
   updateAvailable: false
 })
@@ -133,6 +143,9 @@ export function SettingsProvider(props: Props) {
   const toggleMultiSignature = () => updateSettings({ multisignature: !settings.multisignature })
   const toggleTestnet = () => updateSettings({ testnet: !settings.testnet })
   const toggleHideMemos = () => updateSettings({ hideMemos: !settings.hideMemos })
+  const toggleShowDust = () => updateSettings({ showDust: !settings.showDust })
+  const toggleShowClaimableBalanceTxs = () =>
+    updateSettings({ showClaimableBalanceTxs: !settings.showClaimableBalanceTxs })
 
   const setLanguage = (language: string | undefined) => {
     if (language) {
@@ -174,10 +187,14 @@ export function SettingsProvider(props: Props) {
     setLanguage,
     setSetting,
     showTestnet: settings.testnet,
+    showDust: settings.showDust,
+    showClaimableBalanceTxs: settings.showClaimableBalanceTxs,
     toggleBiometricLock,
     toggleMultiSignature,
     toggleTestnet,
     toggleHideMemos,
+    toggleShowDust,
+    toggleShowClaimableBalanceTxs,
     trustedServices: settings.trustedServices,
     updateAvailable
   }

--- a/src/AppSettings/components/AppSettings.tsx
+++ b/src/AppSettings/components/AppSettings.tsx
@@ -14,6 +14,8 @@ import {
   HideMemoSetting,
   LanguageSetting,
   MultiSigSetting,
+  ShowClaimableBalanceSetting,
+  ShowDustSetting,
   TestnetSetting,
   TrustedServicesSetting
 } from "./Settings"
@@ -73,6 +75,11 @@ function AppSettings() {
         />
         <HideMemoSetting onToggle={settings.toggleHideMemos} value={settings.hideMemos} />
         <MultiSigSetting onToggle={settings.toggleMultiSignature} value={settings.multiSignature} />
+        <ShowDustSetting onToggle={settings.toggleShowDust} value={settings.showDust} />
+        <ShowClaimableBalanceSetting
+          onToggle={settings.toggleShowClaimableBalanceTxs}
+          value={settings.showClaimableBalanceTxs}
+        />
         {trustedServicesEnabled ? <TrustedServicesSetting onClick={navigateToTrustedServices} /> : undefined}
       </List>
       <SettingsDialogs />

--- a/src/AppSettings/components/Settings.tsx
+++ b/src/AppSettings/components/Settings.tsx
@@ -7,6 +7,8 @@ import Switch from "@material-ui/core/Switch"
 import { makeStyles } from "@material-ui/core/styles"
 import ArrowRightIcon from "@material-ui/icons/KeyboardArrowRight"
 import FingerprintIcon from "@material-ui/icons/Fingerprint"
+import BlurOffIcon from "@material-ui/icons/BlurOff"
+import ReportOffIcon from "@material-ui/icons/ReportOff"
 import GroupIcon from "@material-ui/icons/Group"
 import LanguageIcon from "@material-ui/icons/Language"
 import MessageIcon from "@material-ui/icons/Message"
@@ -158,6 +160,42 @@ export const MultiSigSetting = React.memo(function MultiSigSetting(props: Settin
         props.value
           ? t("app-settings.settings.multi-sig.text.secondary.enabled")
           : t("app-settings.settings.multi-sig.text.secondary.disabled")
+      }
+    />
+  )
+})
+
+export const ShowDustSetting = React.memo(function ShowDustSetting(props: SettingProps) {
+  const classes = useSettingsStyles(props)
+  const { t } = useTranslation()
+  return (
+    <AppSettingsItem
+      actions={<SettingsToggle checked={props.value} onChange={props.onToggle} />}
+      icon={<BlurOffIcon className={classes.icon} />}
+      onClick={props.onToggle}
+      primaryText={t("app-settings.settings.dust.text.primary")}
+      secondaryText={
+        props.value
+          ? t("app-settings.settings.dust.text.secondary.shown")
+          : t("app-settings.settings.dust.text.secondary.hidden")
+      }
+    />
+  )
+})
+
+export const ShowClaimableBalanceSetting = React.memo(function ShowClaimableBalanceSetting(props: SettingProps) {
+  const classes = useSettingsStyles(props)
+  const { t } = useTranslation()
+  return (
+    <AppSettingsItem
+      actions={<SettingsToggle checked={props.value} onChange={props.onToggle} />}
+      icon={<ReportOffIcon className={classes.icon} />}
+      onClick={props.onToggle}
+      primaryText={t("app-settings.settings.create-claimable-balance.text.primary")}
+      secondaryText={
+        props.value
+          ? t("app-settings.settings.create-claimable-balance.text.secondary.shown")
+          : t("app-settings.settings.create-claimable-balance.text.secondary.hidden")
       }
     />
   )

--- a/src/Platform/ipc/web.ts
+++ b/src/Platform/ipc/web.ts
@@ -152,7 +152,9 @@ function initSettings() {
     multisignature: true,
     testnet: true,
     trustedServices: [],
-    hideMemos: false
+    hideMemos: false,
+    showDust: false,
+    showClaimableBalanceTxs: false
   }
 
   callHandlers[Messages.BioAuthAvailable] = () => ({ available: false, enrolled: false })


### PR DESCRIPTION
PR adds two switches in app settings:
- "Show Dust Transactions". Default: off
- "Show Claimable Balance Transactions". Default: off

Manually added EN/RU translations. ES/IT translations made via Deepl.

Closes #20 

**Demo:**
1. Both switched off (default)
2. Switching on "Show Dust" only
3. Switching on both "Show Dust" and "Show Claimable Balance"
4. Switching on "Show Claimable Balance" only

https://github.com/Montelibero/mtl_solar/assets/163447/7816e0a4-0109-4516-92b6-9b39f4f0baae


