### PR TITLE
fix: duplicate txs in transaction history

### DIFF
--- a/src/Generic/hooks/stellar-subscriptions.ts
+++ b/src/Generic/hooks/stellar-subscriptions.ts
@@ -376,7 +376,7 @@ export function useOlderTransactions(accountID: string, testnet: boolean) {
         {
           // not an accurate science right now…
           olderTransactionsAvailable: fetchedTransactions.length === limit,
-          transactions: [...(accountTransactionsCache.get(selector)?.transactions || []), ...transactions]
+          transactions: [...prevTransactions, ...transactions]
         },
         true
       )


### PR DESCRIPTION
The reason: sometimes `fetchMoreTransactions` is being called multiple times for the same paging_token. This is likely due to the fact that `fetchMoreTransactions` is being called in `useEffect` and thus may be called multiple times (e.g. on rerender). This is the problem on it is own (excessive requests). However, it was possible that when called twice for the same `paging_token`, the first request updates the cache with new txs and then second requests tries to add the same set of txs to the cache — thus duplicates.

Easy fix is to use local-scoped `prevTransactions` when updating cache — this way the cache will be rewritten, no duplicates. The `inefficiency of multiple requests still stays in the code though, just not visible.`

Proper fix would be to make sure `fetchMoreTransactions` is being called just once per `paging_token`.

----

## How to reproduce the issue

I was able to set up the conditions to reproduce the issue by adding a delay (`await new Promise((resolve) => { setTimeout(resolve, 3000) })`) after the fetch but before the cache update and then resizing the window after "Load more" click. Apparently it leads to rerender and thus a second call.

Closes #16 