### PR TITLE
UI/scroll welcome screen

### DIFF
--- a/src/App/components/TermsAndConditionsDialog.tsx
+++ b/src/App/components/TermsAndConditionsDialog.tsx
@@ -47,7 +47,7 @@ function TermsAndConditions(props: Props) {
   }
 
   return (
-    <Section brandColored top bottom style={{ display: "flex", flexDirection: "column" }}>
+    <Section brandColored top bottom style={{ display: "flex", flexDirection: "column", overflowY: "auto" }}>
       <VerticalLayout grow={1} justifyContent="center" margin="0 auto" padding="3vh 4vw" maxWidth={800}>
         <Typography color="inherit" variant="h4">
           {t("app.terms-and-conditions.header")}

--- a/src/App/components/TermsAndConditionsDialog.tsx
+++ b/src/App/components/TermsAndConditionsDialog.tsx
@@ -53,10 +53,10 @@ function TermsAndConditions(props: Props) {
   return (
     <Section brandColored top bottom style={{ display: "flex", flexDirection: "column", overflowY: "auto" }}>
       <VerticalLayout grow={1} justifyContent="center" margin="0 auto" padding="3vh 4vw" maxWidth={800}>
-        <Typography color="inherit" variant="h4">
+        <Typography color="inherit" variant="h5">
           {t("app.terms-and-conditions.header")}
         </Typography>
-        <FormGroup style={{ margin: "3em 0" }}>
+        <FormGroup style={{ marginTop: "5vh", marginBottom: "5vh" }}>
           <FormControlLabel
             control={
               <Checkbox

--- a/src/App/components/TermsAndConditionsDialog.tsx
+++ b/src/App/components/TermsAndConditionsDialog.tsx
@@ -14,7 +14,11 @@ import { Section } from "~Layout/components/Page"
 const Transition = React.forwardRef((props: TransitionProps, ref) => <Fade ref={ref} {...props} appear={false} />)
 
 function CheckboxLabel(props: { children: React.ReactNode }) {
-  return <span style={{ color: "black", fontSize: "120%" }}>{props.children}</span>
+  return (
+    <Typography variant="body1" style={{ color: "black" }}>
+      {props.children}
+    </Typography>
+  )
 }
 
 function ExternalLink(props: { children: React.ReactNode; href: string }) {


### PR DESCRIPTION
Fix the Welcome screen for devices with a small viewport and RU translation.

Before:
- Checkboxes do not fit in the layout.
- Accept button does not fit in the layout. Unable to hit the button, accept the rules, and use the wallet.

<img width="460" alt="image" src="https://github.com/Montelibero/mtl_solar/assets/32066061/eb30a6a9-66e2-48f8-8d81-ecc96e2c6f9c">
<img width="658" alt="image" src="https://github.com/Montelibero/mtl_solar/assets/32066061/53b183d9-af07-438a-8e95-f92c9d620c7e">


After:
- Allowed scrolling.
- Reduced font size.
- Font size corresponds to the defined template.
- Layout fits in 360x640 viewport.

<img width="466" alt="image" src="https://github.com/Montelibero/mtl_solar/assets/32066061/3b2d1363-0828-411e-ad18-dd62bbf63bd5">
<img width="657" alt="image" src="https://github.com/Montelibero/mtl_solar/assets/32066061/2ce16af4-b432-42ac-9713-7beda2277d48">

