### PR TITLE
Add mobile workflow

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,76 @@
+name: Build mobile wallet
+
+on:
+  workflow_dispatch: # Only manually triggered for this build.
+
+jobs:
+  build-ios:
+      runs-on: macos-latest
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: setup node
+          uses: actions/setup-node@v4
+          with:
+            node-version: 20
+
+        - name: Install project
+          run: |
+            npm install
+            npm run prebuild:electron
+
+        - name: Build project artifacts (iOS)
+          run: |
+            cd cordova
+            npm install
+            npm run install:ios
+            npm run build:ios
+
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          with:
+            name: Solar.app
+            path: /Users/runner/work/mtl_solar/mtl_solar/cordova/platforms/ios/build/emulator/Solar.app
+
+  build-android:
+      runs-on: macos-latest
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: setup node
+          uses: actions/setup-node@v4
+          with:
+            node-version: 20
+
+        - name: setup java
+          uses: actions/setup-java@v4
+          with:
+             java-version: '11'
+             distribution: 'temurin'
+
+        - name: Install Android SDK
+          uses: android-actions/setup-android@v3
+          with:
+            cmdline-tools-version: 8512546
+            packages: ''
+
+        - name: Install Android SDK packages
+          run: sdkmanager "build-tools;30.0.3"
+
+        - name: Install project
+          run: |
+            npm install
+            npm run prebuild:electron
+
+        - name: Build project artifacts (Android)
+          run: |
+            cd cordova
+            npm install
+            npm run install:android
+            npm run build:android
+
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          with:
+            name: app-debug.apk
+            path: /Users/runner/work/mtl_solar/mtl_solar/cordova/platforms/android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Adds mobile build workflow that outputs as build artifact (doesn't add to release).

The mobile build is manually triggered.

Thanks to @bulbigood for contributions as well.