### PR TITLE
Move “Add account“ card to the end of the account list

### DIFF
--- a/src/App/components/AccountList.tsx
+++ b/src/App/components/AccountList.tsx
@@ -168,10 +168,10 @@ function AccountList(props: AccountListProps) {
 
   return (
     <CardList addInvisibleCard={accounts.length % 2 === 0}>
-      <AddAccountCard onClick={props.testnet ? props.onCreateTestnetAccount : props.onCreatePubnetAccount} />
       {accounts.map(account => (
         <AccountCard key={account.id} account={account} pendingSignatureRequests={pendingSignatureRequests} />
       ))}
+      <AddAccountCard onClick={props.testnet ? props.onCreateTestnetAccount : props.onCreatePubnetAccount} />
     </CardList>
   )
 }


### PR DESCRIPTION
Reasons: for a new user this button will already be visible. A user who has more than two accounts will also know about this button.
Its current position at the very beginning of the screen only wastes space. Once configured, users hardly need this button.

![CleanShot 2024-02-28 at 17 50 11@2x](https://github.com/Montelibero/mtl_solar/assets/1482409/0b884ec4-7429-40f9-a741-20284fff3521)
