### PR TITLE
Updated Linux section in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ be required until we have a signed release available.
 
 ### Linux
 
-For Linux, we decided to use the new AppImage installer format. This is included in a lot of
-Linux distributions, including Ubuntu.
+For Linux, we support the portable AppImage format that works across most Linux distributions, including Ubuntu.
 
 Download the latest linux-x86_64.AppImage from the [releases](https://github.com/CityChainFoundation/city-hub/releases) page.
 
@@ -53,7 +52,7 @@ the following command:
 $ chmod a+x Montelibero-Solar-Wallet.*.AppImage
 ```
 
-Then you can simply run the installer:
+Then you can simply run the program:
 
 ```
 $ ./Montelibero-Solar-Wallet.*.AppImage

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ be required until we have a signed release available.
 
 For Linux, we support the portable AppImage format that works across most Linux distributions, including Ubuntu.
 
-Download the latest linux-x86_64.AppImage from the [releases](https://github.com/CityChainFoundation/city-hub/releases) page.
+Download the latest linux-x86_64.AppImage from the [releases](https://github.com/Montelibero/mtl_solar/releases) page.
 
 Open a terminal, navigate to the download folder and make the .AppImage an executeable with
 the following command:


### PR DESCRIPTION
Release URL pointing to CityChain and the AppImage is not new, it is not used as an installer like most AppImages are.