### PR TITLE
enabled multiple entry of the same account if the account is a co-signer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "org.montelibero.solar",
-  "version": "1.0.0-beta",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "org.montelibero.solar",
-      "version": "1.0.0-beta",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "electron-context-menu": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.montelibero.solar",
   "displayName": "MTL Solar",
-  "version": "1.0.0-beta",
+  "version": "1.0.0-beta.2",
   "description": "Wallet for the Stellar payment network by Montelibero.",
   "license": "MIT",
   "private": true,

--- a/src/AccountCreation/hooks/useAccountCreation.ts
+++ b/src/AccountCreation/hooks/useAccountCreation.ts
@@ -8,7 +8,7 @@ import { AccountCreation, AccountCreationErrors } from "../types/types"
 
 function isAccountAlreadyImported(privateKey: string, accounts: Account[], testnet: boolean) {
   const publicKey = Keypair.fromSecret(privateKey).publicKey()
-  return accounts.some(account => account.publicKey === publicKey && account.testnet === testnet)
+  return accounts.some(account => account.publicKey === publicKey && account.testnet === testnet && !account.cosignerOf)
 }
 
 function isValidSecretKey(privateKey: string) {


### PR DESCRIPTION
Proposal for #48  

Solution: Excluded co-signed accounts from public key uniqueness check. 
Performed basic testing on desktop.  