### PR TITLE
fix: allow setting empty SEP-07 /pay fields

### DIFF
--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -294,11 +294,11 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
           <AssetSelector
             assets={props.accountData.balances}
             disableUnderline
-            disabled={!props.canChangePreselectedParams}
+            disabled={!props.canChangePreselectedParams && !!preselectedParams?.asset}
             showXLM
             style={{ alignSelf: "center" }}
             testnet={props.testnet}
-            value={formValues.asset}
+            value={formValues.asset || undefined}
             accountId={props.accountData.account_id}
           />
         }
@@ -338,7 +338,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
     () => (
       <PriceInput
         assetCode={assetSelector}
-        disabled={!props.canChangePreselectedParams}
+        disabled={!props.canChangePreselectedParams && !!preselectedParams?.amount}
         error={Boolean(form.errors.amount)}
         inputRef={form.register({
           required: t<string>("payment.validation.no-price"),
@@ -375,7 +375,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
   const memoInput = React.useMemo(
     () => (
       <TextField
-        disabled={!props.canChangePreselectedParams}
+        disabled={!props.canChangePreselectedParams && !!preselectedParams?.memo}
         error={Boolean(form.errors.memoValue)}
         inputProps={{ maxLength: 28 }}
         label={form.errors.memoValue ? form.errors.memoValue.message : memoMetadata.label}
@@ -454,7 +454,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
 
   return (
     <>
-      <form id={formID} noValidate onSubmit={form.handleSubmit(handleFormSubmission)}>
+      <form id={formID} onSubmit={form.handleSubmit(handleFormSubmission)}>
         {destinationInput}
         <HorizontalLayout justifyContent="space-between" alignItems="top" margin="0 -24px" wrap="wrap">
           {priceInput}

--- a/src/TransactionRequest/components/PaymentRequestContent.tsx
+++ b/src/TransactionRequest/components/PaymentRequestContent.tsx
@@ -103,7 +103,7 @@ function PaymentRequestContent(props: PaymentRequestContentProps) {
     testnet
   )
   const accountData = accountDataSet.find(acc => acc.account_id === props.selectedAccount?.publicKey)
-  const asset = React.useMemo(() => (assetCode && assetIssuer ? new Asset(assetCode, assetIssuer) : Asset.native()), [
+  const asset = React.useMemo(() => (assetCode && assetIssuer ? new Asset(assetCode, assetIssuer) : undefined), [
     assetCode,
     assetIssuer
   ])
@@ -151,7 +151,7 @@ function PaymentRequestContent(props: PaymentRequestContentProps) {
           testnet={testnet}
         />
       ) : (
-        <Typography align="center" color="error" variant="h6" style={{ paddingTop: 16 }}>
+        asset && <Typography align="center" color="error" variant="h6" style={{ paddingTop: 16 }}>
           {asset.code === "XLM"
             ? t("transaction-request.payment.error.no-activated-accounts")
             : t("transaction-request.payment.error.no-accounts-with-trustline")}


### PR DESCRIPTION
SEP-07 requires only 'destination' to be always present on the link, everything else is optional. Let's allow user to enter amount, asset or memo should one or many of these aren't present in SEP-07 link.

If asset, amount or memo is present do not allow to change it — we treat SEP-07 /pay as a strict payment request

Closes #149 