### PR TITLE
add full balance data and copying functionality to AssetDetailsDialog

### DIFF
--- a/src/Account/components/AccountBalances.tsx
+++ b/src/Account/components/AccountBalances.tsx
@@ -2,7 +2,9 @@ import { AllInclusive } from "@material-ui/icons"
 import { Horizon } from "@stellar/stellar-sdk"
 import BigNumber from "big.js"
 import React from "react"
+import { useTranslation } from "react-i18next"
 import { useLiveAccountData } from "~Generic/hooks/stellar-subscriptions"
+import { useClipboard } from "~Generic/hooks/userinterface"
 import { useAssetSettings } from "~Generic/hooks/useAssetSettings"
 import useVisibleBalances from "~Generic/hooks/useVisibleBalances"
 import { BalanceLine } from "~Generic/lib/account"
@@ -16,42 +18,90 @@ interface SingleBalanceProps {
   untrimmed?: boolean
   style?: React.CSSProperties
   showInfinity?: boolean
+  allowCopy?: boolean
 }
 
 export const SingleBalance = React.memo(function SingleBalance(props: SingleBalanceProps) {
-  const balance = BigNumber(props.balance).abs()
+  const clipboard = useClipboard()
+  const { t } = useTranslation()
+  const balance = BigNumber(props.balance)
+  const absoluteBalance = balance.abs()
 
   const formattingOptions: BalanceFormattingOptions = props.untrimmed
-    ? { minimumSignificants: 7 }
-    : balance.eq(0)
+    ? {
+        groupThousands: false,
+        maximumDecimals: 7,
+        maximumSignificants: 100,
+        minimumDecimals: 7
+      }
+    : absoluteBalance.eq(0)
     ? { maximumDecimals: 0, minimumDecimals: 0 }
-    : balance.gt(0) && balance.lt(0.0001)
+    : absoluteBalance.gt(0) && absoluteBalance.lt(0.0001)
     ? { maximumDecimals: 7, minimumDecimals: 7 }
-    : balance.lt(1000)
+    : absoluteBalance.lt(1000)
     ? { maximumDecimals: 4, minimumDecimals: 0 }
     : { maximumDecimals: 0, minimumDecimals: 0 }
 
-  const formattedBalance = formatBalance(balance, formattingOptions)
+  const formattedBalance = formatBalance(absoluteBalance, formattingOptions)
+  const exactBalance = `${balance.lt(0) ? "-" : ""}${formatBalance(absoluteBalance, {
+    groupThousands: false,
+    maximumDecimals: 7,
+    maximumSignificants: 100,
+    minimumDecimals: 7
+  })}`
   const [integerPart, decimalPart = ""] = formattedBalance.split(".")
+
+  const copyHint = t("account-settings.export-key.info.tap-to-copy")
+  const isCopyEnabled = props.allowCopy && !props.showInfinity
+
+  const handleBalanceCopy = React.useCallback(
+    (event: React.MouseEvent<HTMLSpanElement>) => {
+      if (!isCopyEnabled) {
+        return
+      }
+      event.stopPropagation()
+      clipboard.copyToClipboard(exactBalance)
+    },
+    [clipboard, exactBalance, isCopyEnabled]
+  )
+
+  const handleAssetCodeCopy = React.useCallback(
+    (event: React.MouseEvent<HTMLSpanElement>) => {
+      if (!isCopyEnabled || !props.assetCode) {
+        return
+      }
+      event.stopPropagation()
+      clipboard.copyToClipboard(props.assetCode)
+    },
+    [clipboard, isCopyEnabled, props.assetCode]
+  )
+
+  const copyableStyle = isCopyEnabled ? { cursor: "pointer" } : undefined
+
   return (
     <span style={{ whiteSpace: "nowrap", ...props.style }}>
       <span style={{ display: "inline-block", verticalAlign: 'top' }}>
         {balance.gte(0) ? null : <span>-&nbsp;</span>}
-        {!props.showInfinity && <span style={{ fontWeight: 300 }}>
-          {integerPart}
-          <span style={{ opacity: 0.8 }}>{decimalPart ? "." + decimalPart : ""}</span>
-        </span>}
+        {!props.showInfinity && (
+          <span onClick={handleBalanceCopy} style={{ fontWeight: 300, ...copyableStyle }} title={isCopyEnabled ? copyHint : undefined}>
+            {integerPart}
+            <span style={{ opacity: 0.8 }}>{decimalPart ? "." + decimalPart : ""}</span>
+          </span>
+        )}
         {props.showInfinity && <AllInclusive style={{ height: "1.2rem", width: "1.2rem" }} />}
       </span>
       {props.assetCode ? (
         <>
           &nbsp;
           <span
+            onClick={handleAssetCodeCopy}
             style={{
               display: "inline-block",
               fontWeight: props.inline ? undefined : "bold",
-              marginLeft: props.inline ? undefined : "0.4em"
+              marginLeft: props.inline ? undefined : "0.4em",
+              ...copyableStyle
             }}
+            title={isCopyEnabled ? copyHint : undefined}
           >
             {props.assetCode}
           </span>

--- a/src/Assets/components/AssetDetailsDialog.tsx
+++ b/src/Assets/components/AssetDetailsDialog.tsx
@@ -18,6 +18,7 @@ import { AccountName } from "~Generic/components/Fetchers"
 import { ReadOnlyTextfield } from "~Generic/components/FormFields"
 import { Box, VerticalLayout } from "~Layout/components/Box"
 import MainTitle from "~Generic/components/MainTitle"
+import { SingleBalance } from "~Account/components/AccountBalances"
 import AssetDetailsActions from "./AssetDetailsActions"
 import AssetLogo from "./AssetLogo"
 import SpendableBalanceBreakdown from "./SpendableBalanceBreakdown"
@@ -326,15 +327,6 @@ const useAssetDetailStyles = makeStyles({
     alignItems: "center",
     flexWrap: "wrap"
   },
-  copyableValue: {
-    cursor: "pointer",
-    userSelect: "text" as const,
-    WebkitUserSelect: "text" as const
-  },
-  balanceCode: {
-    fontWeight: "bold",
-    marginLeft: 12
-  },
   toolbar: {
     marginLeft: 4
   }
@@ -351,8 +343,6 @@ function AssetDetailsDialog(props: Props) {
   const asset = React.useMemo(() => parseAssetID(props.assetID), [props.assetID])
   const classes = useAssetDetailStyles()
   const isSmallScreen = useIsMobile()
-  const clipboard = useClipboard()
-  const { t } = useTranslation()
 
   const balance = accountData.balances.find(
     asset.isNative()
@@ -362,7 +352,6 @@ function AssetDetailsDialog(props: Props) {
 
   const metadata = useAssetMetadata(asset, props.account.testnet)
   const assetCode = asset.getCode()
-  const copyHint = t("account-settings.export-key.info.tap-to-copy")
 
   const assetTitle = React.useMemo(() => {
     if (asset.isNative()) {
@@ -372,16 +361,6 @@ function AssetDetailsDialog(props: Props) {
     const assetName = metadata?.name?.trim()
     return assetName && assetName !== assetCode ? `${assetName} (${assetCode})` : assetCode
   }, [asset, assetCode, metadata])
-
-  const copyBalanceToClipboard = React.useCallback(() => {
-    if (balance?.balance) {
-      clipboard.copyToClipboard(balance.balance)
-    }
-  }, [balance?.balance, clipboard])
-
-  const copyAssetCodeToClipboard = React.useCallback(() => {
-    clipboard.copyToClipboard(assetCode)
-  }, [assetCode, clipboard])
 
   const dialogActions = React.useMemo(
     () => (asset.isNative() ? null : <AssetDetailsActions account={props.account} asset={asset} />),
@@ -406,24 +385,7 @@ function AssetDetailsDialog(props: Props) {
           <Typography className={classes.domain} component="div" variant="subtitle1">
             {balance ? (
               <Box className={classes.balanceRow}>
-                <Typography
-                  component="span"
-                  onClick={copyBalanceToClipboard}
-                  title={copyHint}
-                  className={classes.copyableValue}
-                  variant="inherit"
-                >
-                  {balance.balance}
-                </Typography>
-                <Typography
-                  component="span"
-                  onClick={copyAssetCodeToClipboard}
-                  title={copyHint}
-                  className={`${classes.copyableValue} ${classes.balanceCode}`}
-                  variant="inherit"
-                >
-                  {assetCode}
-                </Typography>
+                <SingleBalance allowCopy assetCode={assetCode} balance={balance.balance} untrimmed />
                 <Box className={classes.toolbar}>
                   <VisibilityIconButton
                     accountId={props.account.accountID}

--- a/src/Assets/components/AssetDetailsDialog.tsx
+++ b/src/Assets/components/AssetDetailsDialog.tsx
@@ -13,7 +13,6 @@ import { BASE_RESERVE, parseAssetID } from "~Generic/lib/stellar"
 import { openLink } from "~Platform/links"
 import { breakpoints } from "~App/theme"
 import { StellarTomlCurrency } from "~shared/types/stellar-toml"
-import { SingleBalance } from "~Account/components/AccountBalances"
 import DialogBody from "~Layout/components/DialogBody"
 import { AccountName } from "~Generic/components/Fetchers"
 import { ReadOnlyTextfield } from "~Generic/components/FormFields"
@@ -322,8 +321,22 @@ const useAssetDetailStyles = makeStyles({
       marginLeft: 39
     }
   },
+  balanceRow: {
+    display: "flex",
+    alignItems: "center",
+    flexWrap: "wrap"
+  },
+  copyableValue: {
+    cursor: "pointer",
+    userSelect: "text" as const,
+    WebkitUserSelect: "text" as const
+  },
+  balanceCode: {
+    fontWeight: "bold",
+    marginLeft: 12
+  },
   toolbar: {
-    marginLeft: "-4px"
+    marginLeft: 4
   }
 })
 
@@ -338,6 +351,8 @@ function AssetDetailsDialog(props: Props) {
   const asset = React.useMemo(() => parseAssetID(props.assetID), [props.assetID])
   const classes = useAssetDetailStyles()
   const isSmallScreen = useIsMobile()
+  const clipboard = useClipboard()
+  const { t } = useTranslation()
 
   const balance = accountData.balances.find(
     asset.isNative()
@@ -346,6 +361,27 @@ function AssetDetailsDialog(props: Props) {
   )
 
   const metadata = useAssetMetadata(asset, props.account.testnet)
+  const assetCode = asset.getCode()
+  const copyHint = t("account-settings.export-key.info.tap-to-copy")
+
+  const assetTitle = React.useMemo(() => {
+    if (asset.isNative()) {
+      return "Stellar Lumens (XLM)"
+    }
+
+    const assetName = metadata?.name?.trim()
+    return assetName && assetName !== assetCode ? `${assetName} (${assetCode})` : assetCode
+  }, [asset, assetCode, metadata])
+
+  const copyBalanceToClipboard = React.useCallback(() => {
+    if (balance?.balance) {
+      clipboard.copyToClipboard(balance.balance)
+    }
+  }, [balance?.balance, clipboard])
+
+  const copyAssetCodeToClipboard = React.useCallback(() => {
+    clipboard.copyToClipboard(assetCode)
+  }, [assetCode, clipboard])
 
   const dialogActions = React.useMemo(
     () => (asset.isNative() ? null : <AssetDetailsActions account={props.account} asset={asset} />),
@@ -361,31 +397,40 @@ function AssetDetailsDialog(props: Props) {
             nowrap
             onBack={props.onClose}
             style={{ position: "relative", zIndex: 1 }}
-            title={
-              asset.isNative()
-                ? "Stellar Lumens (XLM)"
-                : (<>
-                  {metadata && metadata.name
-                    ? `${metadata.name} (${asset.getCode()})`
-                    : asset.getCode()}
-                </>
-                )
-            }
+            title={assetTitle}
             titleStyle={{
               maxWidth: isSmallScreen ? "calc(100% - 75px)" : "calc(100% - 100px)",
               textShadow: "0 0 5px white, 0 0 5px white, 0 0 5px white"
             }}
           />
-          <Typography className={classes.domain} variant="subtitle1">
-            {balance ? (<>
-              <SingleBalance assetCode={asset.getCode()} balance={balance.balance} />
-              <Box className={classes.toolbar}>
-                <VisibilityIconButton
-                  accountId={props.account.accountID}
-                  asset={asset}
-                />
+          <Typography className={classes.domain} component="div" variant="subtitle1">
+            {balance ? (
+              <Box className={classes.balanceRow}>
+                <Typography
+                  component="span"
+                  onClick={copyBalanceToClipboard}
+                  title={copyHint}
+                  className={classes.copyableValue}
+                  variant="inherit"
+                >
+                  {balance.balance}
+                </Typography>
+                <Typography
+                  component="span"
+                  onClick={copyAssetCodeToClipboard}
+                  title={copyHint}
+                  className={`${classes.copyableValue} ${classes.balanceCode}`}
+                  variant="inherit"
+                >
+                  {assetCode}
+                </Typography>
+                <Box className={classes.toolbar}>
+                  <VisibilityIconButton
+                    accountId={props.account.accountID}
+                    asset={asset}
+                  />
+                </Box>
               </Box>
-            </>
             ) : asset.isNative() ? (
               "stellar.org"
             ) : (


### PR DESCRIPTION
Issue: #194

Как было (дублируется имя и код, если они одинаковы, баланс отображается кратко, расположено всё кривенько):

<img width="1064" height="712" alt="CleanShot 2026-04-01 at 21 26 09@2x" src="https://github.com/user-attachments/assets/cd897515-edd4-447c-9532-78ecff697aee" />


Как стало (полный баланс, до последнего струпа, а также оно кликабельно и не дублируется название, ну и опрятнее):

<img width="1062" height="710" alt="CleanShot 2026-04-01 at 21 21 33@2x" src="https://github.com/user-attachments/assets/50b2b0b6-3e1d-4421-8d66-1aa1b9573d9a" />

