### PR TITLE
fix: do not wait for faulty stellar.toml files

### DIFF
--- a/src/Generic/hooks/stellar.ts
+++ b/src/Generic/hooks/stellar.ts
@@ -129,7 +129,22 @@ export function useStellarToml(domain: string | undefined): StellarToml | undefi
     return cached[1]
   }
 
-  return stellarTomlPersistentCache.read(domain) || stellarTomlCache.suspend(domain, fetchStellarTomlData)
+  const persistentCached = stellarTomlPersistentCache.read(domain)
+
+  if (persistentCached) {
+    return persistentCached
+  }
+
+  try {
+    return stellarTomlCache.suspend(domain, fetchStellarTomlData)
+  } catch (thrown) {
+    // if Promise thrown to suspend component – prevent suspension
+    if (thrown && typeof thrown.then === "function") {
+      return
+    }
+    // It's an error – re-throw
+    throw thrown
+  }
 }
 
 export function useAccountData(accountID: string, testnet: boolean) {

--- a/src/Generic/hooks/stellar.ts
+++ b/src/Generic/hooks/stellar.ts
@@ -129,7 +129,19 @@ export function useStellarToml(domain: string | undefined): StellarToml | undefi
     return cached[1]
   }
 
-  return stellarTomlPersistentCache.read(domain) || stellarTomlCache.suspend(domain, fetchStellarTomlData)
+  const persistentCached = stellarTomlPersistentCache.read(domain)
+  if (persistentCached) {
+    return persistentCached
+  }
+
+  // null = failed to fetch last time
+  // undefined = never fetched
+  if (persistentCached === null) { // 
+    fetchStellarTomlData()
+    return
+  }
+
+  return stellarTomlCache.suspend(domain, fetchStellarTomlData)
 }
 
 export function useAccountData(accountID: string, testnet: boolean) {

--- a/src/Generic/hooks/stellar.ts
+++ b/src/Generic/hooks/stellar.ts
@@ -129,19 +129,7 @@ export function useStellarToml(domain: string | undefined): StellarToml | undefi
     return cached[1]
   }
 
-  const persistentCached = stellarTomlPersistentCache.read(domain)
-  if (persistentCached) {
-    return persistentCached
-  }
-
-  // null = failed to fetch last time
-  // undefined = never fetched
-  if (persistentCached === null) { // 
-    fetchStellarTomlData()
-    return
-  }
-
-  return stellarTomlCache.suspend(domain, fetchStellarTomlData)
+  return stellarTomlPersistentCache.read(domain) || stellarTomlCache.suspend(domain, fetchStellarTomlData)
 }
 
 export function useAccountData(accountID: string, testnet: boolean) {

--- a/src/Workers/net-worker/stellar-ecosystem.ts
+++ b/src/Workers/net-worker/stellar-ecosystem.ts
@@ -61,7 +61,7 @@ export async function fetchAllAssets(tickerURL: string): Promise<AssetRecord[]> 
 
 export async function fetchStellarToml(
   domain: string,
-  options: StellarToml.Api.StellarTomlResolveOptions = { timeout: 5000 }
+  options: StellarToml.Api.StellarTomlResolveOptions = {}
 ): Promise<any> {
   try {
     return await StellarToml.Resolver.resolve(domain, options)

--- a/src/Workers/net-worker/stellar-ecosystem.ts
+++ b/src/Workers/net-worker/stellar-ecosystem.ts
@@ -61,7 +61,7 @@ export async function fetchAllAssets(tickerURL: string): Promise<AssetRecord[]> 
 
 export async function fetchStellarToml(
   domain: string,
-  options: StellarToml.Api.StellarTomlResolveOptions = {}
+  options: StellarToml.Api.StellarTomlResolveOptions = { timeout: 5000 }
 ): Promise<any> {
   try {
     return await StellarToml.Resolver.resolve(domain, options)


### PR DESCRIPTION
Fetching stellar.toml for fourstonesfoundation.com without explicit timeout hangs the UI for long time — server doesn't send response