### PR TITLE
fix: attempt to fix "Fetching source account data timed out" error.

### DIFF
--- a/src/Generic/hooks/stellar.ts
+++ b/src/Generic/hooks/stellar.ts
@@ -186,7 +186,7 @@ export function useAccountHomeDomains(
   const forceRerender = () => setRerenderCounter(counter => counter + 1)
 
   const fetchHomeDomain = async (accountID: string): Promise<[string] | []> => {
-    const accountData = await netWorker.fetchAccountData(horizonURLs, accountID)
+    const accountData = await netWorker.fetchAccountData(horizonURLs, accountID, undefined, true)
     const homeDomain = accountData ? (accountData as any).home_domain : undefined
     if (homeDomain) {
       ;(testnet ? homeDomainCacheTestnet : homeDomainCachePubnet).save(accountID, homeDomain || null)

--- a/src/Generic/lib/third-party-security.ts
+++ b/src/Generic/lib/third-party-security.ts
@@ -38,7 +38,7 @@ export async function isThirdPartyProtected(horizon: Horizon.Server, accountPubK
   const { netWorker } = await workers
   const horizonURL = horizon.serverURL.toString()
 
-  const account = await netWorker.fetchAccountData(horizonURL, accountPubKey)
+  const account = await netWorker.fetchAccountData(horizonURL, accountPubKey, undefined, true)
   const signerKeys = (account?.signers || []).map(signer => signer.key)
 
   const enabledService = services.find(service => signerKeys.includes(service.publicKey))

--- a/src/Generic/lib/transaction.ts
+++ b/src/Generic/lib/transaction.ts
@@ -115,7 +115,7 @@ export async function createTransaction(operations: xdr.Operation<any>[], option
   const timeout = selectTransactionTimeout(options.accountData)
 
   const [accountMetadata, timebounds] = await Promise.all([
-    applyTimeout(netWorker.fetchAccountData(horizonURL, walletAccount.accountID, 10), 10000, () =>
+    applyTimeout(netWorker.fetchAccountData(horizonURL, walletAccount.accountID, 10, true), 10000, () =>
       fail(`Fetching source account data timed out`)
     ),
     applyTimeout(netWorker.fetchTimebounds(horizonURL, timeout), 10000, () =>
@@ -192,7 +192,7 @@ export async function requiresRemoteSignatures(horizon: Server, transaction: Tra
 
   const accounts = await Promise.all(
     sources.map(async sourcePublicKey => {
-      const account = await netWorker.fetchAccountData(horizonURL, sourcePublicKey)
+      const account = await netWorker.fetchAccountData(horizonURL, sourcePublicKey, undefined, true)
       if (!account) {
         throw Error(`Could not fetch account metadata from horizon server: ${sourcePublicKey}`)
       }

--- a/src/TransferService/hooks/useWithdrawalState.ts
+++ b/src/TransferService/hooks/useWithdrawalState.ts
@@ -156,7 +156,7 @@ export function useWithdrawalState(account: Account, closeDialog: () => void) {
     instructions: WithdrawalInstructionsSuccess,
     amount: BigNumber
   ) => {
-    const accountData = await netWorker.fetchAccountData(horizonURLs, account.accountID)
+    const accountData = await netWorker.fetchAccountData(horizonURLs, account.accountID, undefined, true)
     const horizonURL = horizonURLs[0]
 
     if (!accountData) {

--- a/src/Workers/net-worker/stellar-network.ts
+++ b/src/Workers/net-worker/stellar-network.ts
@@ -712,7 +712,8 @@ export interface PaginationOptions {
 export async function fetchAccountData(
   horizonURLs: string | string[],
   accountID: string,
-  priority: number = 2
+  priority: number = 2,
+  skipIssuedAssets = false,
 ): Promise<(Horizon.AccountResponse & { home_domain?: string | undefined }) | null> {
   const horizonURL = Array.isArray(horizonURLs) ? getRandomURL(horizonURLs) : horizonURLs
   const fetchQueue = getFetchQueue(horizonURL)
@@ -725,19 +726,23 @@ export async function fetchAccountData(
 
   const accountData = await parseJSONResponse<Horizon.AccountResponse & { home_domain: string | undefined }>(response)
 
-  const issuedAssets = (await fetchIssuedAssetsData(horizonURL, accountID))._embedded.records.map((a: AssetRecord) => ({
-    balance: "0",
-    limit: "0",
-    asset_type: a.asset_type as any, // TODO: possible to resolve?
-    asset_code: a.asset_code,
-    asset_issuer: a.asset_issuer,
-    buying_liabilities: "0",
-    selling_liabilities: "0",
-    last_modified_ledger: "",
-    is_authorized: true,
-    is_authorized_to_maintain_liabilities: true,
-    is_clawback_enabled: a.flags.auth_clawback_enabled
-  }))
+  let issuedAssets = [] as AssetRecord[]
+
+  if (!skipIssuedAssets) {
+    issuedAssets = (await fetchIssuedAssetsData(horizonURL, accountID))._embedded.records.map((a: AssetRecord) => ({
+      balance: "0",
+      limit: "0",
+      asset_type: a.asset_type as any, // TODO: possible to resolve?
+      asset_code: a.asset_code,
+      asset_issuer: a.asset_issuer,
+      buying_liabilities: "0",
+      selling_liabilities: "0",
+      last_modified_ledger: "",
+      is_authorized: true,
+      is_authorized_to_maintain_liabilities: true,
+      is_clawback_enabled: a.flags.auth_clawback_enabled
+    }))
+  }
   // FIXME: Add support for liquidity pools
   // Remove liquidity pools from account data
   // Add self-issued assets


### PR DESCRIPTION
Hypothesis is the "issued assets" fetching is done in the same request that fetches sequence_no for the source account in Payment Form is slow for some reason. The request itself is absolutely unnecessary in this case.

Short term workaround implemented here: add a flag to skip issued accounts fetching in some cases

Long term solution: remake issued account fetching to be separate request that populates "asset list" when it is needed