### PR TITLE
fix: wrong transaction summary for multisig payments to cosigner

### DIFF
--- a/src/Account/components/SignatureRequestList.tsx
+++ b/src/Account/components/SignatureRequestList.tsx
@@ -26,15 +26,16 @@ function SignatureRequestListItem(props: SignatureRequestListItemProps) {
     signatureRequest.req
   ])
 
-  const openTransaction = React.useCallback(
-    onOpenTransaction ? () => onOpenTransaction(tx, signatureRequest) : () => undefined,
-    [onOpenTransaction, signatureRequest, tx]
-  )
+  const openTransaction = React.useCallback(() => {
+    if (onOpenTransaction) {
+      onOpenTransaction(tx, signatureRequest)
+    }
+  }, [onOpenTransaction, signatureRequest, tx])
 
   return (
     <TransactionListItem
       alwaysShowSource
-      accountPublicKey={tx.source}
+      accountID={tx.source}
       createdAt={signatureRequest.created_at}
       icon={props.icon}
       onOpenTransaction={openTransaction}

--- a/src/Account/components/TransactionList.tsx
+++ b/src/Account/components/TransactionList.tsx
@@ -154,7 +154,7 @@ function TransactionIcon(props: { paymentSummary: PaymentSummary; transaction: T
 }
 
 interface TitleTextProps {
-  accountPublicKey: string
+  accountID: string
   alwaysShowSource?: boolean
   createdAt: string
   paymentSummary: PaymentSummary
@@ -220,7 +220,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
             {props.alwaysShowSource ? (
               <span>
                 &nbsp;{t("account.transactions.transaction-list.item.from")}&nbsp;
-                <PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />{" "}
+                <PublicKey publicKey={props.accountID} testnet={testnet} variant="short" />{" "}
               </span>
             ) : null}
           </span>
@@ -245,7 +245,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
             {props.alwaysShowSource ? (
               <>
                 {" "}
-                (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
+                (<PublicKey publicKey={props.accountID} testnet={testnet} variant="short" />)
               </>
             ) : null}
           </span>
@@ -268,7 +268,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
             {props.alwaysShowSource ? (
               <>
                 {" "}
-                (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
+                (<PublicKey publicKey={props.accountID} testnet={testnet} variant="short" />)
               </>
             ) : null}
           </span>
@@ -295,7 +295,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
               {props.alwaysShowSource ? (
                 <>
                   {" "}
-                  (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
+                  (<PublicKey publicKey={props.accountID} testnet={testnet} variant="short" />)
                 </>
               ) : null}
             </span>
@@ -315,7 +315,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
               {props.alwaysShowSource ? (
                 <>
                   {" "}
-                  (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
+                  (<PublicKey publicKey={props.accountID} testnet={testnet} variant="short" />)
                 </>
               ) : null}
             </span>
@@ -335,7 +335,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
               {props.alwaysShowSource ? (
                 <>
                   {" "}
-                  (<PublicKey publicKey={props.accountPublicKey} testnet={testnet} variant="short" />)
+                  (<PublicKey publicKey={props.accountID} testnet={testnet} variant="short" />)
                 </>
               ) : null}
             </span>
@@ -360,7 +360,7 @@ const TransactionItemText = React.memo(function TransactionItemText(props: Title
 })
 
 function TransactionListItemBalance(props: {
-  accountPublicKey: string
+  accountID: string
   paymentSummary: PaymentSummary
   style?: React.CSSProperties
   transaction: Transaction
@@ -375,7 +375,7 @@ function TransactionListItemBalance(props: {
 
   // Handle special edge case: Sending money from an account to itself
   const balanceChange = paymentSummary.every(payment =>
-    payment.publicKeys.every(pubkey => pubkey === props.accountPublicKey)
+    payment.publicKeys.every(pubkey => pubkey === props.accountID)
   )
     ? sum(...creationOps.map(op => op.startingBalance), ...paymentOps.map(op => op.amount))
     : paymentSummary[0].balanceChange
@@ -394,7 +394,7 @@ function TransactionListItemBalance(props: {
 }
 
 interface TransactionListItemProps {
-  accountPublicKey: string
+  accountID: string
   alwaysShowSource?: boolean
   className?: string
   createdAt: string
@@ -410,7 +410,7 @@ export const TransactionListItem = React.memo(function TransactionListItem(props
 
   const { transaction, onOpenTransaction } = props
 
-  const paymentSummary = getPaymentSummary(props.accountPublicKey, transaction)
+  const paymentSummary = getPaymentSummary(props.accountID, transaction)
   const onOpen = onOpenTransaction ? () => onOpenTransaction(transaction.hash().toString("hex")) : undefined
 
   return (
@@ -419,7 +419,7 @@ export const TransactionListItem = React.memo(function TransactionListItem(props
         {props.icon || <TransactionIcon paymentSummary={paymentSummary} transaction={transaction} />}
       </ListItemIcon>
       <TransactionItemText
-        accountPublicKey={props.accountPublicKey}
+        accountID={props.accountID}
         alwaysShowSource={props.alwaysShowSource}
         createdAt={props.createdAt}
         paymentSummary={paymentSummary}
@@ -434,7 +434,7 @@ export const TransactionListItem = React.memo(function TransactionListItem(props
         transaction={transaction}
       />
       <TransactionListItemBalance
-        accountPublicKey={props.accountPublicKey}
+        accountID={props.accountID}
         paymentSummary={paymentSummary}
         style={{ paddingRight: 0 }}
         transaction={transaction}
@@ -542,7 +542,7 @@ function TransactionList(props: TransactionListProps) {
             <InlineErrorBoundary height={72}>
               <TransactionListItem
                 key={transaction.hash}
-                accountPublicKey={props.account.publicKey}
+                accountID={props.account.accountID}
                 className={classes.listItem}
                 createdAt={transaction.created_at}
                 onOpenTransaction={openTransaction}
@@ -553,7 +553,7 @@ function TransactionList(props: TransactionListProps) {
         ))}
       </>
     ),
-    [props.transactions, props.account.publicKey, classes.listItem, openTransaction]
+    [props.transactions, props.account.accountID, classes.listItem, openTransaction]
   )
 
   if (props.transactions.length === 0 && !props.olderTransactionsAvailable) {

--- a/src/Generic/lib/transaction.ts
+++ b/src/Generic/lib/transaction.ts
@@ -239,13 +239,13 @@ export function isStellarWebAuthTransaction(transaction: Transaction) {
 export const DUST_THRESHOLD = BigNumber(0.01)
 
 export function isDustTransaction(tx: Transaction, account: Account) {
-  const paymentSummary = getPaymentSummary(account.publicKey, tx)
+  const paymentSummary = getPaymentSummary(account.accountID, tx)
 
   // not a payment
   if (paymentSummary.length === 0) return false
 
   // payment to self
-  if (paymentSummary.every(payment => payment.publicKeys.every(pubkey => pubkey === account.publicKey))) return false
+  if (paymentSummary.every(payment => payment.publicKeys.every(pubkey => pubkey === account.accountID))) return false
 
   // native payment with dust amount
   return paymentSummary[0].asset.getCode() === "XLM" && paymentSummary[0].balanceChange.abs().lte(DUST_THRESHOLD)


### PR DESCRIPTION
Fixed by using props.account.accountID instead of props.account.publicKey for TransactionListItem

Changes overview:
- fix itself: just one line [here](https://github.com/SunceWallet/sunce/commit/41c177c0715bf7507a640bf3e673d0a8070ebe17#diff-3aa5fbad243cfc66410c7f9f4e52e96020ebf12acbc2e416323bdaa36a6c1bbfL545) for transaction list item and [here](https://github.com/SunceWallet/sunce/commit/41c177c0715bf7507a640bf3e673d0a8070ebe17#diff-e29f962aa77896beefa2f1ab6941655da20c21d179e94efe8b7ad2d755e0e747L248) to fix isDustTransaction check
- refactoring: renamed accountPublicKey to accountID for clarity. Just a rename

Fixed #232 