### PR TITLE
chore: override vulnerable uuid transitive deps

### DIFF
--- a/cordova/package-lock.json
+++ b/cordova/package-lock.json
@@ -5294,14 +5294,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/valid-identifier": {

--- a/cordova/package.json
+++ b/cordova/package.json
@@ -68,6 +68,11 @@
     "json": "^10.0.0",
     "npm-run-all": "^4.1.5"
   },
+  "overrides": {
+    "xcode": {
+      "uuid": "11.1.1"
+    }
+  },
   "scripts": {
     "install:android": "rm -rf ./plugins && ./scripts/create-config-from-template.sh prod android && cordova platform add android",
     "install:ios": "rm -rf ./plugins && ./scripts/create-config-from-template.sh prod ios && cordova platform add ios && node ./hooks/after_platform_add/set_ios_deployment_target.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15050,10 +15050,9 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -15061,7 +15060,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -161,6 +161,11 @@
     "vite-plugin-compression": "^0.5.1",
     "wait-on": "^7.2.0"
   },
+  "overrides": {
+    "@storybook/addon-actions": {
+      "uuid": "11.1.1"
+    }
+  },
   "browserslist": [
     "Chrome 50",
     "ChromeAndroid 50",


### PR DESCRIPTION
## Summary
- add scoped npm overrides for Storybook and Cordova transitive uuid dependencies
- resolve both root and cordova lockfiles to uuid@11.1.1 for GHSA-w5hq-g745-h8pq

## Verification
- npm ls uuid --all
- npm ls uuid --all --prefix cordova
- npm audit --json (uuid finding removed; unrelated existing root findings remain)
- npm audit --json --prefix cordova (0 vulnerabilities)
- npm run storybook:build
- npm test (fails before ESLint on existing TypeScript errors unrelated to this change)