### PR TITLE
fix(infra): setup CNAME for beta.sunce.app deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,4 +29,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist 
+          publish_dir: ./dist
+          cname: beta.sunce.app


### PR DESCRIPTION
Added CNAME configuration for GitHub Pages deployments. Before this change every deployment reset the CNAME rendering beta.sunce.app broken