### PR TITLE
fix: stale order UI after offer changes

### DIFF
--- a/src/Generic/hooks/_caches.ts
+++ b/src/Generic/hooks/_caches.ts
@@ -135,23 +135,6 @@ function areTransactionsNewer(prev: TransactionHistory, next: TransactionHistory
   return !prev || nextMaxTimestamp > prevMaxTimestamp
 }
 
-function areOffersNewer(prev: OfferHistory, next: OfferHistory) {
-  const prevMaxTimestamp =
-    (prev
-      ? max(
-          prev.offers.map(tx => asComparableTimestamp((tx as any).last_modified_time)),
-          "0"
-        )
-      : undefined) || ""
-  const nextMaxTimestamp =
-    max(
-      next.offers.map(tx => asComparableTimestamp((tx as any).last_modified_time)),
-      "0"
-    ) || ""
-
-  return !prev || nextMaxTimestamp > prevMaxTimestamp
-}
-
 export const accountDataCache = createCache<readonly [string[], string], AccountData, AccountData>(
   createAccountCacheKey
 )
@@ -166,7 +149,7 @@ export const accountOpenOrdersCache = createCache<
   readonly [string[], string],
   OfferHistory,
   Horizon.ServerApi.OfferRecord[]
->(createAccountCacheKey, areOffersNewer)
+>(createAccountCacheKey)
 
 export const accountTransactionsCache = createCache<
   readonly [string[], string],

--- a/src/Workers/net-worker/stellar-network.ts
+++ b/src/Workers/net-worker/stellar-network.ts
@@ -425,12 +425,23 @@ function subscribeToAccountUncached(horizonURLs: string[], accountID: string) {
             return accountData
           }
         }
+        const handleNewOfferUpdate = (newOptimisticUpdate: OptimisticOfferUpdate) => {
+          return newOptimisticUpdate.effectsAccountID === accountID && horizonURLs.includes(newOptimisticUpdate.horizonURL)
+            ? fetchAccountData(newOptimisticUpdate.horizonURL, accountID, 20)
+            : undefined
+        }
         return merge(
           // Update whenever we receive an account effect push notification
           subscribeToAccountEffects(horizonURLs, accountID).pipe(map(() => fetchAccountData(horizonURLs, accountID))),
           // Update on new optimistic updates
           accountDataUpdates.observe().pipe(
             map(handleNewOptimisticUpdate),
+            filter(accountData => Boolean(accountData))
+          ),
+          // Order creation/cancellation changes liabilities, but account effects for
+          // those operations are unreliable. Refresh account data after local offer updates.
+          offerUpdates.observe().pipe(
+            map(handleNewOfferUpdate),
             filter(accountData => Boolean(accountData))
           ),
           // Initially fetch data with a delay to make sure we don't miss anything
@@ -576,8 +587,8 @@ function subscribeToOpenOrdersUncached(horizonURLs: string[], accountID: string)
       },
       subscribeToUpdates() {
         const handleNewOptimisticUpdate = (newOptimisticUpdate: OptimisticOfferUpdate) => {
-          return newOptimisticUpdate.effectsAccountID === accountID && newOptimisticUpdate.horizonURL === horizonURL
-            ? optimisticallyUpdateOffers(horizonURL, accountID, latestSet)
+          return newOptimisticUpdate.effectsAccountID === accountID && horizonURLs.includes(newOptimisticUpdate.horizonURL)
+            ? optimisticallyUpdateOffers(newOptimisticUpdate.horizonURL, accountID, latestSet)
             : latestSet
         }
         // We somewhat rely on the optimistic updates as a trigger to fetch


### PR DESCRIPTION
Updates open-order caching to accept current snapshots so canceled orders can disappear from the UI.

Refreshes account data after local offer updates so liabilities and spendable balances update after order creation or cancellation.

Closes #271