### PR TITLE
fix: buffer SEP-07 deep links on cold start

### DIFF
--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -1,6 +1,20 @@
-// tslint:disable-next-line: no-var-requires
-const { contextBridge, ipcRenderer } = require("electron")
+import { contextBridge, ipcRenderer } from "electron"
+
 const electronProcess = process
+const deepLinkURLMessage = "DeepLinkURL"
+const deepLinkSubscribers = new Set<(url: string) => void>()
+const queuedDeepLinkURLs: string[] = []
+
+function emitDeepLinkURL(url: string) {
+  if (deepLinkSubscribers.size === 0) {
+    queuedDeepLinkURLs.push(url)
+    return
+  }
+
+  deepLinkSubscribers.forEach(callback => callback(url))
+}
+
+ipcRenderer.on(deepLinkURLMessage, (_event: Electron.IpcRendererEvent, url: string) => emitDeepLinkURL(url))
 
 function sendMessage<Message extends keyof IPC.MessageType>(
   messageType: Message,
@@ -45,6 +59,14 @@ function subscribeToIPCMessages<Message extends keyof IPC.MessageType>(
   messageType: Message,
   subscribeCallback: (result: IPC.MessageReturnType<Message>) => void
 ) {
+  if (messageType === deepLinkURLMessage) {
+    const callback = subscribeCallback as (url: string) => void
+    deepLinkSubscribers.add(callback)
+    queuedDeepLinkURLs.splice(0).forEach(callback)
+
+    return () => deepLinkSubscribers.delete(callback)
+  }
+
   const listener = (_event: Electron.IpcRendererEvent, result: IPC.MessageReturnType<Message>) => subscribeCallback(result)
   ipcRenderer.on(messageType, listener)
   const unsubscribe = () => ipcRenderer.removeListener(messageType, listener)

--- a/src/App/cordova/protocol-handler.ts
+++ b/src/App/cordova/protocol-handler.ts
@@ -1,8 +1,24 @@
 import { Messages } from "~shared/ipc"
 import { expose } from "./ipc"
 
+let postDeepLinkURL: ((url: string) => void) | undefined
+const queuedDeepLinkURLs: string[] = []
+
+window.handleOpenURL = (url: string) => {
+  if (postDeepLinkURL) {
+    postDeepLinkURL(url)
+  } else {
+    queuedDeepLinkURLs.push(url)
+  }
+}
+
 export function registerURLHandler(contentWindow: Window, iframeReady: Promise<void>) {
-  window.handleOpenURL = handleOpenURL(contentWindow, iframeReady)
+  postDeepLinkURL = (url: string) => {
+    iframeReady.then(() => {
+      contentWindow.postMessage({ messageType: Messages.DeepLinkURL, result: url }, "*")
+    })
+  }
+  queuedDeepLinkURLs.splice(0).forEach(postDeepLinkURL)
 
   // there is no way we can check for default handler in cordova
   expose(Messages.IsDefaultProtocolClient, () => {
@@ -15,11 +31,5 @@ export function registerURLHandler(contentWindow: Window, iframeReady: Promise<v
 
   expose(Messages.SetAsDefaultProtocolClient, () => {
     return true
-  })
-}
-
-const handleOpenURL = (contentWindow: Window, iframeReady: Promise<void>) => (url: string) => {
-  iframeReady.then(() => {
-    contentWindow.postMessage({ messageType: Messages.DeepLinkURL, result: url }, "*")
   })
 }

--- a/src/Platform/ipc/cordova.ts
+++ b/src/Platform/ipc/cordova.ts
@@ -1,7 +1,28 @@
 import { CustomError } from "../../Generic/lib/errors"
+import { Messages } from "../../shared/ipc"
 import pick from "lodash.pick"
 
 let nextCallID = 1
+const deepLinkSubscribers = new Set<(url: string) => void>()
+const queuedDeepLinkURLs: string[] = []
+
+function emitDeepLinkURL(url: string) {
+  if (deepLinkSubscribers.size === 0) {
+    queuedDeepLinkURLs.push(url)
+    return
+  }
+
+  deepLinkSubscribers.forEach(callback => callback(url))
+}
+
+window.addEventListener("message", event => {
+  if (event instanceof MessageEvent && event.source === window.parent) {
+    const message = event.data
+    if (message && typeof message === "object" && message.messageType === Messages.DeepLinkURL) {
+      emitDeepLinkURL(message.result)
+    }
+  }
+})
 
 export function call<Message extends keyof IPC.MessageType>(
   messageType: Message,
@@ -48,6 +69,13 @@ export function subscribeToMessages<Message extends keyof IPC.MessageType>(
   messageType: Message,
   callback: (message: any) => void
 ): UnsubscribeFn {
+  if (messageType === Messages.DeepLinkURL) {
+    deepLinkSubscribers.add(callback)
+    queuedDeepLinkURLs.splice(0).forEach(callback)
+
+    return () => deepLinkSubscribers.delete(callback)
+  }
+
   const eventListener = (event: Event) => {
     if (event instanceof MessageEvent && event.source === window.parent) {
       if (event.data.messageType === messageType) {

--- a/src/Transaction/lib/stellar-uri.ts
+++ b/src/Transaction/lib/stellar-uri.ts
@@ -14,10 +14,7 @@ export async function verifyTransactionRequest(request: string, options: Verific
     if (parsedURI.isTestNetwork && options.allowUnsafeTestnetURIs) {
       // ignore
     } else {
-      const unsignedRequest = new URL(request)
-      unsignedRequest.searchParams.delete("origin_domain")
-      unsignedRequest.searchParams.delete("signature")
-      return verifyTransactionRequest(unsignedRequest.toString(), options)
+      throw CustomError("StellarUriVerificationError", i18next.t("stellar-uri-verification-error"))
     }
   }
 

--- a/src/Transaction/lib/stellar-uri.ts
+++ b/src/Transaction/lib/stellar-uri.ts
@@ -14,7 +14,10 @@ export async function verifyTransactionRequest(request: string, options: Verific
     if (parsedURI.isTestNetwork && options.allowUnsafeTestnetURIs) {
       // ignore
     } else {
-      throw CustomError("StellarUriVerificationError", i18next.t("stellar-uri-verification-error"))
+      const unsignedRequest = new URL(request)
+      unsignedRequest.searchParams.delete("origin_domain")
+      unsignedRequest.searchParams.delete("signature")
+      return verifyTransactionRequest(unsignedRequest.toString(), options)
     }
   }
 


### PR DESCRIPTION
## Summary
- Buffer SEP-07 deep-link events until the renderer subscribes on Cordova and Electron.
- Register Cordova handleOpenURL early so cold-start URLs are not dropped before the iframe bridge is ready.

Closes #272