### PR TITLE
fix: provide Buffer for Stellar signing

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,1 @@
+import "../src/polyfills"

--- a/src/App/bootstrap.cordova.ts
+++ b/src/App/bootstrap.cordova.ts
@@ -1,1 +1,2 @@
+import "../polyfills"
 import "./cordova/app.cordova"

--- a/src/Workers/net-worker.ts
+++ b/src/Workers/net-worker.ts
@@ -1,3 +1,4 @@
+import "../polyfills"
 import DebugLogger from "debug"
 import { registerSerializer } from "threads"
 import { expose } from "threads/worker"

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,3 +1,4 @@
+import "./polyfills"
 import SmoothScroll from "smoothscroll-polyfill"
 import handleSplashScreen from "./SplashScreen/splash-screen"
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,1 +1,3 @@
-import "core-js/es6"
+import { Buffer } from "buffer"
+
+;(globalThis as typeof globalThis & { Buffer: typeof Buffer }).Buffer = Buffer


### PR DESCRIPTION
"Buffer is undefined" error when singing SEP-07 requests. Regression issue

## Summary
- Define globalThis.Buffer from the buffer package in the shared polyfills entry
- Load that polyfill before browser, Cordova, worker, and Storybook code
- Remove the stale core-js/es6 import that was not resolving once the polyfills file became active

## Problem
Stellar SDK internals still reference global Buffer during keypair/signing/XDR flows. SEP-07 signing can hit transaction.sign and fail with Buffer is not defined after the broad node polyfills plugin was removed.

## Verification
- npm run build:web
- npm run storybook:build
- npm run prebuild:electron:bundle
- Minimal Stellar SDK signing check with only globalThis.Buffer supplied