### PR TITLE
fix(pwa): make new service worker update to apply on restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '22'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build website
         env:
@@ -27,21 +27,9 @@ jobs:
         run: |
           npm run build:web
 
-      # GitHub Pages caches HTML after the deployment action removes its hashed assets.
-      # Restore three releases so a stale app shell can load and update itself.
-      - name: Restore previous hashed assets
-        run: |
-          git fetch origin gh-pages:refs/remotes/origin/gh-pages --depth=4
-          mkdir previous-assets
-          for release in origin/gh-pages~1 origin/gh-pages~2 origin/gh-pages~3; do
-            git archive --format=tar "$release" | tar -x -C previous-assets
-          done
-          cp previous-assets/*-*.js previous-assets/*-*.css dist/
-
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           cname: beta.sunce.app
-          keep_files: true

--- a/pwa-manifest.ts
+++ b/pwa-manifest.ts
@@ -1,7 +1,7 @@
 import type { VitePWAOptions } from 'vite-plugin-pwa'
 
 export const pwaOptions: Partial<VitePWAOptions> = {
-  registerType: 'autoUpdate',
+  registerType: 'prompt',
   manifest: {
     name: 'Sunce Wallet',
     short_name: 'Sunce',


### PR DESCRIPTION
Having "prompt" strategy without the actual prompt in UI works like this: 
1. User opens app version A. Service worker A is installed and activate
2. App updates to B
3. User opens the app again. He uses service worker A which still serves cached assets for A. Service worker B is installed, but not activated ("waiting")
4. User reloads the app (e.g. close browser window and open again). Service worker B is activated and assets for B are served and cached now

Also here in this PR:
- cleanup previous PWA-related fixes (these were only temporary to fix beta.sunce.app stale SW)
- use `npm ci` in CI pipeline instead of `npm install` to have reproducible installs (`npm ci` use lock file always without updating it)
