### PR TITLE
feat: support muxed addresses in payment QR codes

### DIFF
--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -210,7 +210,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
       const [destination, query] = scanResult.split("?")
 
       // handle plain address or Kraken-style uri (<destination>?dt=<memoid>)
-      if (isPublicKey(destination) || isStellarAddress(destination)) {
+      if (isPublicKey(destination) || isMuxedAddress(destination) || isStellarAddress(destination)) {
         setValue("destination", destination)
 
         if (!query) {


### PR DESCRIPTION
## Summary

Adds support for muxed Stellar addresses in the payment QR scanner.

Previously, scanned `M...` addresses were ignored because the QR handler only accepted regular public keys and Stellar federation addresses. They are now accepted and passed to the existing payment flow.

## Testing

- Scanned a QR payload containing a muxed address.
- Verified that the destination is populated in the payment form.